### PR TITLE
Update tensorflow to 1.13.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 comet_ml
-tensorflow<1.12.0
+tensorflow==1.13.1
 numpy
 matplotlib
 keras


### PR DESCRIPTION
Tested by running

```
comet-tensorflow-mnist-example.py
comet-tensorflow-word2vec-example.py
```

They still to work with no problem.