### PR TITLE
Fix PyTorch example train accuracy

### DIFF
--- a/pytorch/comet-pytorch-mnist-example.py
+++ b/pytorch/comet-pytorch-mnist-example.py
@@ -101,7 +101,7 @@ with experiment.train():
             correct += float((predicted == labels.data).sum())
 
             # Log accuracy to Comet.ml
-            experiment.log_metric("accuracy", correct / total, step=step)
+            experiment.log_metric("accuracy", 100 * correct / total, step=step)
             step += 1
 
             if (i + 1) % 100 == 0:


### PR DESCRIPTION
Before this fix, the train accuracy is reported as 0.

By the way, the PyTorch example you chose makes no sense. It uses a RNN on a batch of shuffled  MNIST images. The RNN's hidden state is useless in this case. There also isn't any explanation of what's happening (neither on the author's repo). There are more reasonable examples in: https://github.com/pytorch/examples. I could open another PR to replace the example, if you'd like.