### PR TITLE
Distributed Estimator Fixes

### DIFF
--- a/tensorflow-1/README.md
+++ b/tensorflow-1/README.md
@@ -66,9 +66,9 @@ You can start the MirroredWorker strategy example with the following command, it
 python comet-tf1-distributed-mirrored-strategy.py
 ```
 
-### MultiWorkerMirrored strategy example
+### MultiWorkerMirrored Estimator strategy example
 
-To start the MultiWorkerMirrored strategy with TF Estimator we will need to start a chief process, an evaluator process and a worker process. We will also need to supply a `run_id` for the training run so that metrics from each process can be logged to a single experiment. The `run_id` is a string that is hashed to compute the Experiment ID. We also recommend allocating a single GPU to each process used in this example. 
+To start the MultiWorkerMirrored strategy with TF Estimator we will need to start a chief process, an evaluator process and a worker process. We will also need to supply a `run_id` for the training run so that metrics from each process can be logged to a single experiment. The `run_id` is a string that is hashed to compute the Experiment ID. We also recommend allocating a single GPU to each process used in this example. This can be done by setting the `CUDA_VISIBLE_DEVICES` envrionment variable to the appropriate GPU ID. For example, `export CUDA_VISIBLE_DEVICES=0` will only allow the process to access GPU ID 0. 
 
 **Note:** You will need to start the evaluator process before starting the chief and worker process. 
 

--- a/tensorflow-1/README.md
+++ b/tensorflow-1/README.md
@@ -68,10 +68,26 @@ python comet-tf1-distributed-mirrored-strategy.py
 
 ### MultiWorkerMirrored strategy example
 
-You can start the MultiWorkerMirrored strategy example with the following command, it will automatically uses all available GPU and you only need to launch the command once:
+To start the MultiWorkerMirrored strategy with TF Estimator we will need to start a chief process, an evaluator process and a worker process. We will also need to supply a `run_id` for the training run so that metrics from each process can be logged to a single experiment. The `run_id` is a string that is hashed to compute the Experiment ID. We also recommend allocating a single GPU to each process used in this example. 
+
+**Note:** You will need to start the evaluator process before starting the chief and worker process. 
+
+The following command will start a evaluator process on `localhost:8002` with `task_index == 0`. 
 
 ```
-python comet-tf1-distributed-estimator-multiworker-mirrored-strategy.py
+python comet-tf1-distributed-estimator-multiworker-mirrored-strategy.py --chief_host localhost:8000 --worker_hosts localhost:8001 --eval_hosts localhost:8002 --task_index 0 --task_type evaluator --run_id <your run id>
+```
+
+The following command will start a chief process on `localhost:8000` with `task_index == 0`. 
+
+```
+python comet-tf1-distributed-estimator-multiworker-mirrored-strategy.py --chief_host localhost:8000 --worker_hosts localhost:8001 --eval_hosts localhost:8003 --task_index 0 --task_type chief --run_id <your run id>
+
+```
+The following command will start a worker process on `localhost:8001` with `task_index == 0`. 
+
+```
+python comet-tf1-distributed-estimator-multiworker-mirrored-strategy.py --chief_host localhost:8000 --worker_hosts localhost:8001 --eval_hosts localhost:8003 --task_index 0 --task_type worker --run_id <your run id>
 ```
 
 ### Parameter Server Strategy example

--- a/tensorflow-1/comet-tf1-distributed-estimator-multiworker-mirrored-strategy.py
+++ b/tensorflow-1/comet-tf1-distributed-estimator-multiworker-mirrored-strategy.py
@@ -12,28 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-
-
 import comet_ml
 import tensorflow as tf
 
+import argparse
+import hashlib
 import numpy as np
 import os, json
 
-N_REPLICAS = len(tf.config.experimental.get_visible_devices(device_type="GPU"))
+from hooks import CometSessionHook
 
-print("Number of available devices: ", N_REPLICAS)
+PROJECT_NAME = 'tf-estimator-multiworker'
+BUFFER_SIZE = 60000
+BATCH_SIZE = 8
 
-BUFFER_SIZE = 10000
-BATCH_SIZE = 64
-GLOBAL_BATCH_SIZE = BATCH_SIZE * N_REPLICAS
 LEARNING_RATE = 1e-5
-EPOCHS = 10
+EPOCHS = 2
 
-experiment = comet_ml.Experiment()
+tf.logging.set_verbosity(tf.logging.INFO)
 
-fashion_mnist = tf.keras.datasets.fashion_mnist
-(train_images, train_labels), (test_images, test_labels) = fashion_mnist.load_data()
+mnist = tf.keras.datasets.mnist
+(train_images, train_labels), (test_images, test_labels) = mnist.load_data()
 
 train_images = train_images[..., None]
 test_images = test_images[..., None]
@@ -47,6 +46,9 @@ test_labels = test_labels.astype("int64")
 
 def input_fn(mode, input_context=None):
     train_dataset = tf.data.Dataset.from_tensor_slices((train_images, train_labels))
+    test_dataset = tf.data.Dataset.from_tensor_slices((test_images, test_labels))
+
+    dataset = train_dataset if mode == tf.estimator.ModeKeys.TRAIN else test_dataset
 
     def scale(image, label):
         image = tf.cast(image, tf.float32)
@@ -54,19 +56,22 @@ def input_fn(mode, input_context=None):
         return image, label
 
     if input_context:
-        train_dataset = train_dataset.shard(
+        dataset = dataset.shard(
             input_context.num_input_pipelines, input_context.input_pipeline_id
         )
     return (
-        train_dataset.map(scale)
+        dataset.map(scale)
         .cache()
         .shuffle(BUFFER_SIZE)
-        .batch(GLOBAL_BATCH_SIZE)
+        .batch(BATCH_SIZE)
         .repeat(EPOCHS)
     )
 
 
-def model_fn(features, labels, mode):
+def model_fn(features, labels, mode, params):
+    global_batch_size = BATCH_SIZE * params["n_workers"]
+  
+    experiment = get_experiment(params["run_id"], exists=True)
     model = tf.keras.Sequential(
         [
             tf.keras.layers.Conv2D(32, 3, activation="relu", input_shape=(28, 28, 1)),
@@ -77,29 +82,68 @@ def model_fn(features, labels, mode):
         ]
     )
     logits = model(features, training=False)
-    metrics_dict = {"accuracy": tf.metrics.accuracy(labels, tf.argmax(logits, axis=-1))}
 
     if mode == tf.estimator.ModeKeys.PREDICT:
         predictions = {"logits": logits}
         return tf.estimator.EstimatorSpec(labels=labels, predictions=predictions)
 
     optimizer = tf.compat.v1.train.GradientDescentOptimizer(learning_rate=LEARNING_RATE)
-    cross_entropy = tf.nn.sparse_softmax_cross_entropy_with_logits(
-        logits=logits, labels=labels
+    cross_entropy = tf.losses.sparse_softmax_cross_entropy(
+        logits=logits, labels=labels, reduction=tf.losses.Reduction.NONE
     )
-    loss = tf.reduce_sum(cross_entropy) * (1.0 / GLOBAL_BATCH_SIZE)
-
+    loss = tf.reduce_sum(cross_entropy) * (1.0 / (global_batch_size))
+    comet_hook = CometSessionHook(
+        experiment,
+        tensors={f"loss:{params['task_type']}/{params['task_index']}" : loss},
+        parameters=None,
+        every_n_iter=1
+    )
+    
     if mode == tf.estimator.ModeKeys.EVAL:
-        return tf.estimator.EstimatorSpec(mode, loss=loss, eval_metric_ops=metrics_dict)
+        return tf.estimator.EstimatorSpec(mode, loss=loss, evaluation_hooks=[comet_hook])
 
     return tf.estimator.EstimatorSpec(
         mode=mode,
         loss=loss,
+        training_hooks=[comet_hook],
         train_op=optimizer.minimize(
             loss, tf.compat.v1.train.get_or_create_global_step()
         ),
     )
 
+
+def get_experiment(run_id, exists=False):
+    experiment_id = hashlib.md5(run_id.encode('utf-8')).hexdigest()    
+    os.environ['COMET_EXPERIMENT_KEY'] = experiment_id
+    
+    if exists:
+        return comet_ml.ExistingExperiment(project_name=PROJECT_NAME)
+
+    return comet_ml.Experiment(project_name=PROJECT_NAME)
+
+
+def get_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--run_id")
+    parser.add_argument("--task_type")
+    parser.add_argument("--task_index", type=int)
+    parser.add_argument("--chief_host")
+    parser.add_argument("--worker_hosts")
+    parser.add_argument("--eval_hosts")
+
+    return parser.parse_args()
+
+args = get_args()
+
+worker_hosts = args.worker_hosts.split(",")
+eval_hosts = args.eval_hosts.split(",")
+n_workers = len(worker_hosts)
+
+cluster_dict = {
+    "cluster": {"chief": [args.chief_host], "worker": worker_hosts, "evaluator": eval_hosts},
+    "task": {"type": args.task_type, "index": args.task_index},
+}
+os.environ["TF_CONFIG"] = json.dumps(cluster_dict)
 
 strategy = tf.distribute.experimental.MultiWorkerMirroredStrategy()
 config = tf.estimator.RunConfig(
@@ -109,13 +153,24 @@ config = tf.estimator.RunConfig(
     protocol="grpc",
 )
 
+if args.task_type == "chief":
+    experiment = get_experiment(args.run_id)
+    experiment.log_code("./hooks.py")
+
+else:
+    experiment = get_experiment(args.run_id, exists=True)
+
 classifier = tf.estimator.Estimator(
-    model_fn=model_fn, model_dir="/tmp/multiworker", config=config
+    model_fn=model_fn, model_dir="/tmp/multiworker", config=config, params={
+        "task_index": args.task_index, 
+        "n_workers": n_workers, 
+        "task_type": args.task_type,
+        "task_index": args.task_index, 
+        "run_id": args.run_id
+        } 
 )
 tf.estimator.train_and_evaluate(
     classifier,
-    train_spec=tf.estimator.TrainSpec(input_fn=input_fn),
-    eval_spec=tf.estimator.EvalSpec(
-        input_fn=input_fn, start_delay_secs=5, throttle_secs=10
-    ),
+    train_spec=tf.estimator.TrainSpec(input_fn=input_fn, max_steps=5000),
+    eval_spec=tf.estimator.EvalSpec(input_fn=input_fn, throttle_secs=10, start_delay_secs=10)
 )


### PR DESCRIPTION
This PR:

Fixes the issue in the Estimator example using the MultiworkerMirrored strategy for distributed training. The old example was not running true distributed training. It was using a single worker process that had multiple GPUs allocated to it, rather than using multiple worker processes distributed across GPUs.

Updates the README instructions on how to run this example.