### PR TITLE
Updates to DDP Examples

### DIFF
--- a/pytorch/README.md
+++ b/pytorch/README.md
@@ -1,6 +1,6 @@
 # comet-pytorch-example
 
-#### Using Comet.ml to track PyTorch experiments
+## Using Comet.ml to track PyTorch experiments
 
 The following code snippets shows how to use PyTorch with Comet.ml. Based on the tutorial from [Yunjey](https://github.com/yunjey/pytorch-tutorial/blob/master/tutorials/01-basics/feedforward_neural_network/main.py) this code trains an RNN to detect hand writted digits from the MNIST dataset.
 
@@ -8,26 +8,124 @@ By initializing the `Experiment()` object, Comet.ml will log stdout and source c
 
 Find out more about how you can customize Comet.ml in our documentation: https://www.comet.ml/docs/
 
-##### Using Comet.ml with Pytorch Parallel Data training
+## Using Comet.ml with Pytorch Distributed Data Parallel (DDP) training
 
-This directory contains an example how to track an experiment when using Pytorch DDP for Data Parallelism across multiple machines. The example files are named `comet-pytorch-ddp-mnist-example.py` and `comet-pytorch-ddp-cifar10.py`. You can launch either of them in the following way:
+### Setup
+All machines on the network need to be able to talk to each-other on the unprivileged port range (1024-65535) in addition to the master port. 
 
-* You will need X machines, each of them should have Pytorch and Comet.ml installed. Also make sure the Comet API Key is either configured on the system or update the script to hard-code it. They need to be able to talk to each-other on the unprivileged port range (1024-65535) in addition to the master port. You will need to find the IP of the "master" node that is reachable by all of the other machines, `MASTER_ADDR`. Make sure all of the machines have the same number of GPUS, `Y`.
-* On the master node, run the script like that: `python comet-pytorch-ddp-mnist-example.py --nodes X --gpus Y --nr 0 --master_addr MASTER_ADDR --master_port 8892`
-* On the next node, run the script like this: `python comet-pytorch-ddp-mnist-example.py --nodes X --gpus Y --nr 1 --master_addr MASTER_ADDR --master_port 8892`
-* On the next node, run the script like this: `python comet-pytorch-ddp-mnist-example.py --nodes X --gpus Y --nr 2 --master_addr MASTER_ADDR --master_port 8892`
-* ...
-* On the last node, run the script like this: `python comet-pytorch-ddp-mnist-example.py --nodes X --gpus Y --nr X-1 --master_addr MASTER_ADDR --master_port 8892`
+You will need to define the IP, `master_addr`, of the "master" node that is reachable by all of the other machines and the port, `master_port`, on which the workers will connect. Make sure all of the machines have the same number of GPUS.
 
-For example, with 2 machines, each having 2 gpus and the master node IP being `192.168.1.1`, to run the distributed training:
-* On the master node: `python comet-pytorch-ddp-mnist-example.py --nodes 2 --gpus 2 --nr 0 --master_addr 192.168.1.1 --master_port 8892`
-* On the other node: `python comet-pytorch-ddp-mnist-example.py --nodes 2 --gpus 2 --nr 1 --master_addr 192.168.1.1 --master_port 8892`
+### Logging Metrics from Multiple Machines 
+To capture model metrics and system metrics (GPU/CPU Usage, RAM etc) from each machine while running distributed training, we recommend creating an Experiment object per GPU process, and grouping these experiments under a user provided run ID. 
 
->If you're curious about learning more on  parallelized training in Pytorch, checkout our report [here](https://www.comet.ml/team-comet-ml/parallelism/reports/advanced-ml-parallelism
-)
+An example project can be found [here.](https://www.comet.ml/team-comet-ml/pytorch-ddp-cifar10/view/Tzf2pUfV5BWOVa36eWoW0HOO1)
 
-##### Using Comet.ml with Horovod and Pytorch
+In order to reproduce the project, you will need to run the `comet-pytorch-ddp-cifar10.py` example. The example can be run in the following ways
+
+- Single Machine, Multiple GPUs
+- Multiple Machines, Multiple GPUs
+
+##### Running the Example
+We will run the example based on the assumption that we have 2 machines, with a single GPU each. We will use `192.168.1.1` as our `master_addr` and `8892` as our `master_port`.  
+
+On the master node, start the script with the following command
+
+```
+python comet-pytorch-ddp-cifar10.py \
+--nodes 2 \
+--gpus 1 \
+--node_rank 0 \
+--master_addr 192.168.1.1 \
+--master_port 8892 \
+--epochs 5 \
+--replica_batch_size 32 \
+--run_id <your run name>
+```
+
+On the worker node run 
+
+```
+python comet-pytorch-ddp-cifar10.py \
+--nodes 2 \
+--gpus 1 \
+--node_rank 1 \
+--master_addr 172.31.15.59 \
+--master_port 8892 \
+--epochs 5 \
+--replica_batch_size 32 \
+--run_id <your run name>
+```
+
+The command line arguments are: 
+
+```
+nodes: The number of available compute nodes
+
+gpus: The number of GPUs available on each machine
+
+node_rank: The ranking of the machine within the nodes. It starts at 0
+
+replica_batch_size: The batch size allocated to a single GPU process
+
+run_id: A user provided string that allows us to group the experiments from a single run. 
+```
+
+As you add machines and GPUs, you will have to run the same command on each machine while incrementing the `node_rank`. For example in the case of N machines, we would run the script on each machine up until `node_rank = N-1`
+
+### Logging Metrics from Multiple Machines as a single Experiment
+
+If you would like to log the metrics from each worker as a single experiment, you will need to run the `comet-pytorch-ddp-mnist-single-experiment.py` example. Keep in mind, logging system metrics (CPU/GPU Usage, RAM, etc) from mutiple workers as a single experiment is not currently supported. We recommend using an Experiment per GPU process instead.            
+
+An example project can be found [here.](https://www.comet.ml/team-comet-ml/pytorch-ddp-mnist-single/view/new)
+
+##### Running the Example
+We will run the example based on the assumption that we have 2 machines, with a single GPU each. We will use `192.168.1.1` as our `master_addr` and `8892` as our `master_port`.  
+
+On the master node, start the script with the following command 
+
+```
+python comet-pytorch-ddp-mnist-single-experiment.py \
+--nodes 2 \
+--gpus 1 \
+--master_addr 192.168.1.1 \
+--master_port 8892 \
+--node_rank 0 \
+--local_rank 0 \ 
+--run_id <your run name>
+```
+
+In this case, the sha256 hash of the `run_id` string will be used to create an experiment key for the Experiment that will be used to log the metrics from each worker.   
+
+On the worker node run
+
+```
+python comet-pytorch-ddp-mnist-single-experiment.py \
+--nodes 2 \
+--gpus 1 \
+--master_addr 192.168.1.1 \
+--master_port 8892 \
+--node_rank 1 \
+--local_rank 0 \ 
+--run_id <your run name>
+```
+
+The command line arguments are: 
+
+```
+nodes: The number of available compute nodes
+
+gpus: The number of GPUs available on each machine
+
+node_rank: The ranking of the machine within the nodes. It starts at 0
+
+local_rank: The rank of the process within the current node
+
+run_id: A user provided string 
+```
+
+### Using Comet.ml with Horovod and Pytorch
 In order to run the Horovod example in a distributed manner, you will need the following
+
 ```bash
 1. At least 2 machines 1 gpu each.
 2. Ensure that the master node has ssh access to the worker machines without requiring a password
@@ -39,3 +137,6 @@ To the run the example
 ```
 horovodrun --gloo -np <Number of Nodes * Number of GPUS> -H <server1_address:num_gpus>,<server2_address:num_gpus>,<server3_address:num_gpus> python comet-pytorch-horovod-example.py
 ```
+
+>If you're curious about learning more on parallelized training in Pytorch, checkout our report [here](https://www.comet.ml/team-comet-ml/parallelism/reports/advanced-ml-parallelism
+)

--- a/pytorch/comet-pytorch-ddp-mnist-single-experiment.py
+++ b/pytorch/comet-pytorch-ddp-mnist-single-experiment.py
@@ -1,0 +1,218 @@
+import comet_ml
+
+import os
+import argparse
+import hashlib
+
+import torch
+import torchvision
+import torch.distributed as dist
+import torch.multiprocessing as mp
+from torchvision import datasets, transforms
+from torch.nn.parallel import DistributedDataParallel as DDP
+from torch import nn, optim
+from collections import OrderedDict
+from tqdm import tqdm
+
+torch.manual_seed(0)
+transform = transforms.Compose(
+    [transforms.ToTensor(), transforms.Normalize((0.5,), (0.5,))]
+)
+
+PROJECT_NAME = os.environ.get("COMET_PROJECT_NAME", "pytorch-ddp-mnist-single")
+INPUT_SIZE = 784
+HIDDEN_SIZES = [128, 64]
+OUTPUT_SIZE = 10
+BATCH_SIZE = 256
+
+
+def get_experiment(run_id):
+    experiment_id = hashlib.sha1(run_id.encode("utf-8")).hexdigest()
+    os.environ["COMET_EXPERIMENT_KEY"] = experiment_id
+
+    api = comet_ml.API()  # Assumes API key is set in config/env
+    api_experiment = api.get_experiment_by_id(experiment_id)
+
+    if api_experiment is None:
+        return comet_ml.Experiment(project_name=PROJECT_NAME)
+
+    else:
+        return comet_ml.ExistingExperiment(project_name=PROJECT_NAME)
+
+
+def setup():
+    # initialize the process group
+    dist.init_process_group(backend="nccl", init_method="env://")
+
+
+def cleanup():
+    dist.destroy_process_group()
+
+
+def build_model():
+    model = nn.Sequential(
+        OrderedDict(
+            [
+                ("linear0", nn.Linear(INPUT_SIZE, HIDDEN_SIZES[0])),
+                ("activ0", nn.ReLU()),
+                ("linear1", nn.Linear(HIDDEN_SIZES[0], HIDDEN_SIZES[1])),
+                ("activ1", nn.ReLU()),
+                ("linear2", nn.Linear(HIDDEN_SIZES[1], OUTPUT_SIZE)),
+                ("output", nn.LogSoftmax(dim=1)),
+            ]
+        )
+    )
+
+    return model
+
+
+def train(model, optimizer, criterion, trainloader, epoch, process_rank, experiment):
+    model.train()
+    for batch_idx, (images, labels) in tqdm(enumerate(trainloader)):
+        optimizer.zero_grad()
+        images = images.cuda(non_blocking=True)
+        labels = labels.cuda(non_blocking=True)
+
+        images = images.view(images.size(0), -1)
+        pred = model(images)
+
+        loss = criterion(pred, labels)
+        loss.backward()
+
+        experiment.log_metric(f"{process_rank}_train_batch_loss", loss.item())
+
+        optimizer.step()
+
+
+def run(local_rank, args):
+    """
+    This is a single process that is linked to a single GPU
+
+    :param local_rank: The id of the GPU on the current node
+    :param args:
+    :return:
+    """
+    setup()
+
+    # The overall rank of this GPU process across multiple nodes
+    world_size = dist.get_world_size()
+    global_process_rank = dist.get_rank()
+    print(f"Running DDP model on Global Process with Rank: {global_process_rank }.")
+
+    # Set GPU to local device
+    torch.cuda.set_device(f"cuda:{local_rank}")
+
+    experiment = args.experiment
+
+    model = build_model()
+    model.cuda(local_rank)
+    ddp_model = DDP(model, device_ids=[local_rank])
+
+    criterion = nn.CrossEntropyLoss().cuda(local_rank)
+    optimizer = optim.Adam(ddp_model.parameters())
+
+    # Load training data
+    train_dataset = torchvision.datasets.MNIST(
+        root="./data", train=True, transform=transforms.ToTensor(), download=True
+    )
+    train_sampler = torch.utils.data.distributed.DistributedSampler(
+        train_dataset, num_replicas=world_size, rank=global_process_rank
+    )
+    trainloader = torch.utils.data.DataLoader(
+        dataset=train_dataset,
+        batch_size=BATCH_SIZE,
+        shuffle=False,
+        num_workers=0,
+        pin_memory=True,
+        sampler=train_sampler,
+    )
+
+    for epoch in range(1, args.epochs + 1):
+        train(
+            ddp_model,
+            optimizer,
+            criterion,
+            trainloader,
+            epoch,
+            global_process_rank,
+            experiment,
+        )
+
+    cleanup()
+    experiment.end()
+
+
+def get_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--run_id", type=str)
+    parser.add_argument("-b", "--backend", type=str, default="nccl")
+    parser.add_argument(
+        "--master_addr",
+        type=str,
+        default="localhost",
+        help="""Address of master, will default to localhost if not provided.
+        Master must be able to accept network traffic on the address + port.""",
+    )
+    parser.add_argument(
+        "--master_port",
+        type=str,
+        default="8892",
+        help="""Port that master is listening on, will default to 29500 if not
+        provided. Master must be able to accept network traffic on the host and port.""",
+    )
+    parser.add_argument(
+        "-n",
+        "--nodes",
+        default=1,
+        type=int,
+        metavar="N",
+        help="total number of compute nodes",
+    )
+    parser.add_argument(
+        "-g", "--gpus", default=1, type=int, help="number of gpus per node"
+    )
+    parser.add_argument(
+        "-nr",
+        "--node_rank",
+        default=0,
+        type=int,
+        help="ranking within the nodes, starts at 0",
+    )
+    parser.add_argument(
+        "-lr",
+        "--local_rank",
+        default=0,
+        type=int,
+        help="rank of the process within the current node, starts at 0",
+    )
+    parser.add_argument(
+        "--epochs",
+        default=2,
+        type=int,
+        metavar="N",
+        help="number of total epochs to run",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = get_args()
+
+    world_size = args.gpus * args.nodes
+    global_process_rank = args.node_rank * args.gpus + args.local_rank
+
+    experiment = get_experiment(args.run_id)
+
+    # Make sure all nodes can talk to each other on the unprivileged port range
+    # (1024-65535) in addition to the master port
+    os.environ["MASTER_ADDR"] = args.master_addr
+    os.environ["MASTER_PORT"] = args.master_port
+    os.environ["WORLD_SIZE"] = str(world_size)
+    os.environ["RANK"] = str(global_process_rank)
+
+    args.experiment = experiment
+    run(args.local_rank, args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR:
   
- Adds recommendations to the README for different ways to run DDP with Pytorch and Comet
- Adds links to DDP projects to provide more context to the examples 
- Cleans up and adds more comprehensive logging  to the `comet-pytorch-ddp-cifar10.py` example.   
- Adds an example `comet-pytorch-ddp-mnist-single.py` to cover logging multiple GPU worker metrics to a single experiment 
