### PR TITLE
change default project name and clear cell outputs

### DIFF
--- a/integrations/model-training/pytorch/notebooks/Comet_and_Pytorch.ipynb
+++ b/integrations/model-training/pytorch/notebooks/Comet_and_Pytorch.ipynb
@@ -36,48 +36,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "id": "vIQsPNvatQIU"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Requirement already satisfied: comet_ml in /home/lothiraldan/.virtualenvs/tempenv-35e01882660c8/lib/python3.7/site-packages (3.31.5)\n",
-      "Requirement already satisfied: torch in /home/lothiraldan/.virtualenvs/tempenv-35e01882660c8/lib/python3.7/site-packages (1.11.0)\n",
-      "Requirement already satisfied: torchvision in /home/lothiraldan/.virtualenvs/tempenv-35e01882660c8/lib/python3.7/site-packages (0.12.0)\n",
-      "Requirement already satisfied: tqdm in /home/lothiraldan/.virtualenvs/tempenv-35e01882660c8/lib/python3.7/site-packages (4.64.0)\n",
-      "Requirement already satisfied: wrapt>=1.11.2 in /home/lothiraldan/.virtualenvs/tempenv-35e01882660c8/lib/python3.7/site-packages (from comet_ml) (1.14.1)\n",
-      "Requirement already satisfied: dulwich!=0.20.33,>=0.20.6 in /home/lothiraldan/.virtualenvs/tempenv-35e01882660c8/lib/python3.7/site-packages (from comet_ml) (0.20.43)\n",
-      "Requirement already satisfied: jsonschema!=3.1.0,>=2.6.0 in /home/lothiraldan/.virtualenvs/tempenv-35e01882660c8/lib/python3.7/site-packages (from comet_ml) (4.6.0)\n",
-      "Requirement already satisfied: nvidia-ml-py3>=7.352.0 in /home/lothiraldan/.virtualenvs/tempenv-35e01882660c8/lib/python3.7/site-packages (from comet_ml) (7.352.0)\n",
-      "Requirement already satisfied: websocket-client>=0.55.0 in /home/lothiraldan/.virtualenvs/tempenv-35e01882660c8/lib/python3.7/site-packages (from comet_ml) (1.3.3)\n",
-      "Requirement already satisfied: everett[ini]>=1.0.1 in /home/lothiraldan/.virtualenvs/tempenv-35e01882660c8/lib/python3.7/site-packages (from comet_ml) (3.0.0)\n",
-      "Requirement already satisfied: requests>=2.18.4 in /home/lothiraldan/.virtualenvs/tempenv-35e01882660c8/lib/python3.7/site-packages (from comet_ml) (2.28.0)\n",
-      "Requirement already satisfied: six in /home/lothiraldan/.virtualenvs/tempenv-35e01882660c8/lib/python3.7/site-packages (from comet_ml) (1.16.0)\n",
-      "Requirement already satisfied: wurlitzer>=1.0.2 in /home/lothiraldan/.virtualenvs/tempenv-35e01882660c8/lib/python3.7/site-packages (from comet_ml) (3.0.2)\n",
-      "Requirement already satisfied: requests-toolbelt>=0.8.0 in /home/lothiraldan/.virtualenvs/tempenv-35e01882660c8/lib/python3.7/site-packages (from comet_ml) (0.9.1)\n",
-      "Requirement already satisfied: sentry-sdk>=1.1.0 in /home/lothiraldan/.virtualenvs/tempenv-35e01882660c8/lib/python3.7/site-packages (from comet_ml) (1.6.0)\n",
-      "Requirement already satisfied: semantic-version>=2.8.0 in /home/lothiraldan/.virtualenvs/tempenv-35e01882660c8/lib/python3.7/site-packages (from comet_ml) (2.10.0)\n",
-      "Requirement already satisfied: typing-extensions in /home/lothiraldan/.virtualenvs/tempenv-35e01882660c8/lib/python3.7/site-packages (from torch) (4.2.0)\n",
-      "Requirement already satisfied: pillow!=8.3.*,>=5.3.0 in /home/lothiraldan/.virtualenvs/tempenv-35e01882660c8/lib/python3.7/site-packages (from torchvision) (9.1.1)\n",
-      "Requirement already satisfied: numpy in /home/lothiraldan/.virtualenvs/tempenv-35e01882660c8/lib/python3.7/site-packages (from torchvision) (1.21.6)\n",
-      "Requirement already satisfied: certifi in /home/lothiraldan/.virtualenvs/tempenv-35e01882660c8/lib/python3.7/site-packages (from dulwich!=0.20.33,>=0.20.6->comet_ml) (2022.6.15)\n",
-      "Requirement already satisfied: urllib3>=1.24.1 in /home/lothiraldan/.virtualenvs/tempenv-35e01882660c8/lib/python3.7/site-packages (from dulwich!=0.20.33,>=0.20.6->comet_ml) (1.26.9)\n",
-      "Requirement already satisfied: configobj in /home/lothiraldan/.virtualenvs/tempenv-35e01882660c8/lib/python3.7/site-packages (from everett[ini]>=1.0.1->comet_ml) (5.0.6)\n",
-      "Requirement already satisfied: attrs>=17.4.0 in /home/lothiraldan/.virtualenvs/tempenv-35e01882660c8/lib/python3.7/site-packages (from jsonschema!=3.1.0,>=2.6.0->comet_ml) (21.4.0)\n",
-      "Requirement already satisfied: importlib-metadata in /home/lothiraldan/.virtualenvs/tempenv-35e01882660c8/lib/python3.7/site-packages (from jsonschema!=3.1.0,>=2.6.0->comet_ml) (4.12.0)\n",
-      "Requirement already satisfied: pyrsistent!=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0 in /home/lothiraldan/.virtualenvs/tempenv-35e01882660c8/lib/python3.7/site-packages (from jsonschema!=3.1.0,>=2.6.0->comet_ml) (0.18.1)\n",
-      "Requirement already satisfied: importlib-resources>=1.4.0 in /home/lothiraldan/.virtualenvs/tempenv-35e01882660c8/lib/python3.7/site-packages (from jsonschema!=3.1.0,>=2.6.0->comet_ml) (5.8.0)\n",
-      "Requirement already satisfied: idna<4,>=2.5 in /home/lothiraldan/.virtualenvs/tempenv-35e01882660c8/lib/python3.7/site-packages (from requests>=2.18.4->comet_ml) (3.3)\n",
-      "Requirement already satisfied: charset-normalizer~=2.0.0 in /home/lothiraldan/.virtualenvs/tempenv-35e01882660c8/lib/python3.7/site-packages (from requests>=2.18.4->comet_ml) (2.0.12)\n",
-      "Requirement already satisfied: zipp>=3.1.0 in /home/lothiraldan/.virtualenvs/tempenv-35e01882660c8/lib/python3.7/site-packages (from importlib-resources>=1.4.0->jsonschema!=3.1.0,>=2.6.0->comet_ml) (3.8.0)\n",
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%pip install comet_ml torch torchvision tqdm"
    ]
@@ -93,23 +56,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "id": "kGyz_i-dtfk4"
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "COMET INFO: Comet API key is valid\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import comet_ml\n",
     "\n",
-    "comet_ml.init()"
+    "comet_ml.init(project_name=\"comet-example-pytorch\")"
    ]
   },
   {
@@ -123,7 +78,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
     "id": "cuRPreREp8y0"
    },
@@ -149,24 +104,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "id": "rZ9biJqMtMq0"
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "COMET WARNING: As you are running in a Jupyter environment, you will need to call `experiment.end()` when finished to ensure all metrics and code are logged before exiting.\n",
-      "COMET INFO: Experiment is live on comet.ml https://www.comet.ml/examples/comet-example-pytorch-notebook/f8d0806284a845b5a1e715f0687d72c0\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "hyper_params = {\"batch_size\": 100, \"num_epochs\": 2, \"learning_rate\": 0.01}\n",
-    "experiment = comet_ml.Experiment(project_name=\"comet-example-pytorch-notebook\")\n",
+    "experiment = comet_ml.Experiment()\n",
     "experiment.log_parameters(hyper_params)"
    ]
   },
@@ -181,7 +126,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {
     "id": "crCfZX9Zrufn"
    },
@@ -217,7 +162,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
     "id": "pMRQESULrzXg"
    },
@@ -270,7 +215,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
     "id": "zmb3DAsXqa4K"
    },
@@ -315,55 +260,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {
     "id": "kpNDbdvQuPZw"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Running Model Training\n",
-      "Epoch: 0/2\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 600/600 [01:22<00:00,  7.23it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch: 1/2\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 600/600 [01:23<00:00,  7.17it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch: 2/2\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 600/600 [01:22<00:00,  7.26it/s]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Train the Model\n",
     "print(\"Running Model Training\")\n",
@@ -386,7 +287,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {
     "id": "Oz6E13NtqSZn"
    },
@@ -416,26 +317,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {
     "id": "FUEXkJV6uUW1"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Running Model Evaluation\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100it [00:05, 17.14it/s]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Test the Model\n",
     "print(\"Running Model Evaluation\")\n",
@@ -455,46 +341,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {
     "id": "YsTMrwd_2cmo"
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "COMET INFO: ---------------------------\n",
-      "COMET INFO: Comet.ml Experiment Summary\n",
-      "COMET INFO: ---------------------------\n",
-      "COMET INFO:   Data:\n",
-      "COMET INFO:     display_summary_level : 1\n",
-      "COMET INFO:     url                   : https://www.comet.ml/examples/comet-example-pytorch-notebook/f8d0806284a845b5a1e715f0687d72c0\n",
-      "COMET INFO:   Metrics [count] (min, max):\n",
-      "COMET INFO:     test_accuracy               : 0.9825\n",
-      "COMET INFO:     test_loss                   : 0.0005924321083463838\n",
-      "COMET INFO:     train_accuracy [3]          : (0.8782, 0.9522333333333334)\n",
-      "COMET INFO:     train_batch_accuracy [1800] : (0.07, 1.0)\n",
-      "COMET INFO:     train_loss [183]            : (0.001614484393938134, 2.312751054763794)\n",
-      "COMET INFO:   Parameters:\n",
-      "COMET INFO:     batch_size    : 100\n",
-      "COMET INFO:     learning_rate : 0.01\n",
-      "COMET INFO:     num_epochs    : 2\n",
-      "COMET INFO:   Uploads:\n",
-      "COMET INFO:     environment details      : 1\n",
-      "COMET INFO:     filename                 : 1\n",
-      "COMET INFO:     git metadata             : 1\n",
-      "COMET INFO:     git-patch (uncompressed) : 1 (117.03 KB)\n",
-      "COMET INFO:     installed packages       : 1\n",
-      "COMET INFO:     model graph              : 1\n",
-      "COMET INFO:     notebook                 : 1\n",
-      "COMET INFO:     source_code              : 1\n",
-      "COMET INFO: ---------------------------\n",
-      "COMET INFO: Uploading metrics, params, and assets to Comet before program termination (may take several seconds)\n",
-      "COMET INFO: The Python SDK has 3600 seconds to finish before aborting...\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "experiment.end()"
    ]


### PR DESCRIPTION
This PR:

1. Changes the default logging project in the Pytorch notebook to `comet-example-pytorch`
2. Clears all existing outputs from notebook cells. 