### PR TITLE
Speed up YOLOv5 notebook

### DIFF
--- a/integrations/model-training/yolov5/notebooks/Comet_and_YOLOv5.ipynb
+++ b/integrations/model-training/yolov5/notebooks/Comet_and_YOLOv5.ipynb
@@ -167,7 +167,7 @@
     "!{sys.executable} train.py \\\n",
     "--img 640 \\\n",
     "--batch 16 \\\n",
-    "--epochs 5 \\\n",
+    "--epochs 3 \\\n",
     "--data coco128.yaml \\\n",
     "--weights yolov5s.pt \\\n",
     "--bbox_interval 1 \\\n",
@@ -200,35 +200,7 @@
     "!{sys.executable} train.py \\\n",
     "--img 640 \\\n",
     "--batch 16 \\\n",
-    "--epochs 5 \\\n",
-    "--data coco128.yaml \\\n",
-    "--weights yolov5s.pt \\\n",
-    "--bbox_interval 1"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "F1Sqw8G3QOVx"
-   },
-   "source": [
-    "### Controlling the number of Prediction Images logged to Comet\n",
-    "\n",
-    "When logging predictions from YOLOv5, Comet will log the images associated with each set of predictions. By default a maximum of 100 validation images are logged. You can increase or decrease this number using the `COMET_MAX_IMAGE_UPLOADS` environment variable.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "0pqsQ2PBQZE7"
-   },
-   "outputs": [],
-   "source": [
-    "!env COMET_MAX_IMAGE_UPLOADS=200 {sys.executable} train.py \\\n",
-    "--img 640 \\\n",
-    "--batch 16 \\\n",
-    "--epochs 5 \\\n",
+    "--epochs 3 \\\n",
     "--data coco128.yaml \\\n",
     "--weights yolov5s.pt \\\n",
     "--bbox_interval 1"
@@ -256,7 +228,7 @@
     "!env COMET_LOG_PER_CLASS_METRICS=true {sys.executable} train.py \\\n",
     "--img 640 \\\n",
     "--batch 16 \\\n",
-    "--epochs 5 \\\n",
+    "--epochs 3 \\\n",
     "--data coco128.yaml \\\n",
     "--bbox_interval 1 \\\n",
     "--weights yolov5s.pt "
@@ -287,7 +259,7 @@
     "!{sys.executable} train.py \\\n",
     "--img 640 \\\n",
     "--batch 16 \\\n",
-    "--epochs 5 \\\n",
+    "--epochs 3 \\\n",
     "--data coco128.yaml \\\n",
     "--weights yolov5s.pt \\\n",
     "--bbox_interval 1 \\\n",


### PR DESCRIPTION
Reduce the number of epochs and skip one example that highlight a configuration variable