### PR TITLE
fix: use canonical package name torch-tb-profiler in Tensorboard panel

### DIFF
--- a/panels/TensorboardTorchProfilerViewer/TensorboardTorchProfilerViewer.py
+++ b/panels/TensorboardTorchProfilerViewer/TensorboardTorchProfilerViewer.py
@@ -1,4 +1,4 @@
-%pip install torch_tb_profiler
+%pip install torch-tb-profiler
 
 # Comet Python Panel for visualizing Pytorch Profiler information through Tensorboard
 # Log the torch profile .pt.trace.json file with 


### PR DESCRIPTION
## Summary

- Changes `%pip install torch_tb_profiler` to `%pip install torch-tb-profiler` (underscores → dashes)

## Why

The panel engine's `is_pip_installed_package()` checks whether a package is already installed before running pip. It uses `Requirement.name` which does **not** normalize underscores to dashes, but `pip freeze` outputs the canonical PyPI name `torch-tb-profiler` (dashes). This mismatch caused the already-installed check to always return `False`, so pip install re-ran on **every** Streamlit script execution — even after the package was already installed.

Under normal conditions this showed up as the `Installing packages...` spinner appearing twice per panel load. Under heavy load (e.g. 64 × 100MB trace files causing slow init and concurrent Streamlit re-runs), multiple processes would pile up waiting for the global pip lock and eventually hit the retry limit, producing:

> `Unable to acquire lock for pip installer; try again later`

Using the canonical dash-separated name fixes the installed check so pip only runs once on a fresh container.

## Test plan
- [ ] Open the TensorboardTorchProfilerViewer panel on an existing project
- [ ] Confirm `Installing packages...` spinner only appears on first-ever load (not on subsequent widget interactions)
- [ ] Confirm no `Unable to acquire lock for pip installer` errors

Relates to CUST-5526.

🤖 Generated with [Claude Code](https://claude.com/claude-code)