### PR TITLE
chore: add contributor/agent harness

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,28 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git:*)",
+      "Bash(python:*)",
+      "Bash(python3:*)",
+      "Bash(pip:*)",
+      "Bash(poetry:*)",
+      "Bash(ls:*)",
+      "Bash(find:*)",
+      "Bash(grep:*)",
+      "Bash(jq:*)",
+      "Bash(echo:*)",
+      "Read(*)"
+    ],
+    "deny": [
+      "Read(.env)",
+      "Bash(rm -rf /*)",
+      "Bash(git reset --hard:*)",
+      "Bash(git rebase:*)",
+      "Bash(git merge:*)",
+      "Bash(git branch -D:*)",
+      "Bash(gh pr merge:*)",
+      "Bash(gh pr close:*)",
+      "Bash(gh pr review:*)"
+    ]
+  }
+}

--- a/.claude/skills/scaffold-example/SKILL.md
+++ b/.claude/skills/scaffold-example/SKILL.md
@@ -6,11 +6,11 @@ description: Scaffold a brand-new Comet example in this repo from the canonical 
 # Scaffold a new Comet example
 
 This repo has one canonical example shape, a real, runnable template under
-[`templates/integration-example/`](../../../templates/integration-example): a single `comet_ml`
-script (`example_integration.py`), a `requirements.txt`, and a README in the house structure
-(Title → Documentation → See it → Setup → Run the example). Getting it right by hand is fiddly and
-easy to drift on. This skill copies the template and renames it, so you start from something that
-already runs.
+[`templates/integration-example/`](../../../templates/integration-example): a `uv` project
+(`pyproject.toml`), a single `comet_ml` script (`example_integration.py`), and a README in the house
+structure (Title → Documentation → See it → Setup → Run the example). Getting it right by hand is
+fiddly and easy to drift on. This skill copies the template and renames it, so you start from
+something that already runs.
 
 ## When to refuse
 
@@ -43,8 +43,7 @@ python .claude/skills/scaffold-example/scripts/scaffold.py <name> \
 names it chose and a next-steps checklist.
 
 The name is normalised: the folder and Comet project use kebab-case, the Python file uses
-snake_case (so it stays importable). The description is printed for you to paste into the README
-intro — there's no structured field for it.
+snake_case (so it stays importable). The description is written into the `pyproject.toml`.
 
 ## Step 2 — Make it real
 
@@ -53,7 +52,7 @@ The scaffold runs as-is but is generic. Fill the parts marked `TODO`:
 - **`<name>.py`** — replace the stub loop with the real instrumentation: your framework's training
   or inference, plus the `comet_ml` logging that matters (`log_parameters`, `log_metrics`,
   `log_model`, …). Keep the `comet_ml.login(...)` + `comet_ml.start()` + `experiment.end()` frame.
-- **`requirements.txt`** — add the framework dependency alongside the pinned `comet_ml`.
+- **`pyproject.toml`** — add the framework dependency alongside the pinned `comet_ml`.
 - **`README.md`** — fill the title, intro (paste the description), the docs link, and a public
   Comet project link if one exists. This is required for every example (see
   [AGENTS.md](../../../AGENTS.md)).
@@ -65,9 +64,9 @@ Keep the repo conventions: credentials from env vars only, `# WHY:`-only comment
 From the new example directory:
 
 ```bash
-python -m pip install -r requirements.txt
-python <name>.py                       # logs a real run (needs COMET_API_KEY)
-COMET_MODE=offline python <name>.py    # runs without an account, if practical
+uv sync
+uv run python <name>.py                       # logs a real run (needs COMET_API_KEY)
+COMET_MODE=offline uv run python <name>.py    # runs without an account, if practical
 ```
 
 To get the example tested, add it to the matrix in

--- a/.claude/skills/scaffold-example/SKILL.md
+++ b/.claude/skills/scaffold-example/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: scaffold-example
+description: Scaffold a brand-new Comet example in this repo from the canonical template under templates/integration-example/. Use whenever the user wants to create, add, or start a new example, demo, or integration on Comet — phrasings like "add a Comet example for X", "scaffold an integration example", "create a new example for <framework>", "start a hello-world for <library>", "set up a new example project". Do NOT hand-build the folder structure or copy files manually — this skill stamps out the example and renames it correctly. Require a name and a one-line description of what it does; refuse to invent an example from nothing.
+---
+
+# Scaffold a new Comet example
+
+This repo has one canonical example shape, a real, runnable template under
+[`templates/integration-example/`](../../../templates/integration-example): a single `comet_ml`
+script (`example_integration.py`), a `requirements.txt`, and a README in the house structure
+(Title → Documentation → See it → Setup → Run the example). Getting it right by hand is fiddly and
+easy to drift on. This skill copies the template and renames it, so you start from something that
+already runs.
+
+## When to refuse
+
+You need two things:
+
+- A **name** (kebab-case, e.g. `pytorch-amp-example`, `keras-mnist-dnn`). It becomes the folder, the
+  Python module, and the Comet project name (`comet-example-<name>`).
+- A **one-line description** of what it does.
+
+If either is missing, ask one short question. Don't invent an example — an empty scaffold with a
+guessed purpose wastes the user's time.
+
+## Step 1 — Generate the example
+
+Run the bundled generator. It copies the template, renames its sentinel identity
+(`example_integration` / `example-integration`) to the new name, and refuses to overwrite an
+existing folder.
+
+```bash
+python .claude/skills/scaffold-example/scripts/scaffold.py <name> \
+  --description "<one line>" \
+  --dest <parent-dir>
+```
+
+`--dest` is the parent directory (default `integrations`). New examples live under
+`integrations/<category>/<framework>/`, so pass e.g.
+`--dest integrations/model-training/pytorch`. Categories in use: `model-training`,
+`model-evaluation`, `model-optimization`, `model-deployment`, `workflow-orchestration`,
+`reinforcement-learning`, `llm`, `data-management`. The script prints the folder / script / project
+names it chose and a next-steps checklist.
+
+The name is normalised: the folder and Comet project use kebab-case, the Python file uses
+snake_case (so it stays importable). The description is printed for you to paste into the README
+intro — there's no structured field for it.
+
+## Step 2 — Make it real
+
+The scaffold runs as-is but is generic. Fill the parts marked `TODO`:
+
+- **`<name>.py`** — replace the stub loop with the real instrumentation: your framework's training
+  or inference, plus the `comet_ml` logging that matters (`log_parameters`, `log_metrics`,
+  `log_model`, …). Keep the `comet_ml.login(...)` + `comet_ml.start()` + `experiment.end()` frame.
+- **`requirements.txt`** — add the framework dependency alongside the pinned `comet_ml`.
+- **`README.md`** — fill the title, intro (paste the description), the docs link, and a public
+  Comet project link if one exists. This is required for every example (see
+  [AGENTS.md](../../../AGENTS.md)).
+
+Keep the repo conventions: credentials from env vars only, `# WHY:`-only comments, no emojis.
+
+## Step 3 — Verify
+
+From the new example directory:
+
+```bash
+python -m pip install -r requirements.txt
+python <name>.py                       # logs a real run (needs COMET_API_KEY)
+COMET_MODE=offline python <name>.py    # runs without an account, if practical
+```
+
+To get the example tested, add it to the matrix in
+[`.github/workflows/test-examples.yml`](../../../.github/workflows/test-examples.yml) — the
+`notebooks` list for a `.ipynb`, or the `example` list for a script. See
+[CONTRIBUTING.md](../../../CONTRIBUTING.md#ci).
+
+## What this skill does NOT do
+
+- **No git commit / PR.** Leave the new files in the working tree for the user to review.
+- **No domain logic.** It scaffolds; you (with the user) write the actual instrumentation, deps, and README.

--- a/.claude/skills/scaffold-example/scripts/scaffold.py
+++ b/.claude/skills/scaffold-example/scripts/scaffold.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Scaffold a new Comet example by copying and renaming the canonical template.
+
+One template lives under `templates/integration-example/`: a single `comet_ml` script, a
+`requirements.txt`, and a README in the house structure. It is a real, runnable example under a
+sentinel identity (`example_integration` / `example-integration`). This script copies it to the
+target directory and rewrites those sentinels to the new name — a pure identifier rename, no
+template language. Run it, then fill in the TODO stubs.
+
+  python scaffold.py pytorch-amp-example --description "..." --dest integrations/model-training/pytorch
+"""
+
+import argparse
+import re
+import shutil
+import sys
+from pathlib import Path
+
+TEMPLATE_DIR = ("templates", "integration-example")
+PKG_SENTINEL = "example_integration"  # snake_case: the .py module name
+PROJECT_SENTINEL = "example-integration"  # kebab-case: folder + comet project name
+
+EXCLUDE = shutil.ignore_patterns(
+    ".venv", "__pycache__", "*.pyc", ".ruff_cache", ".env", "*.log", ".tmp"
+)
+
+
+def to_snake(name: str) -> str:
+    s = re.sub(r"[^0-9a-zA-Z]+", "_", name.strip().lower()).strip("_")
+    if not s:
+        raise ValueError(f"cannot derive a name from {name!r}")
+    if s[0].isdigit():
+        s = f"x_{s}"
+    return s
+
+
+def to_kebab(snake: str) -> str:
+    return snake.replace("_", "-")
+
+
+def is_text(path: Path) -> bool:
+    try:
+        path.read_text(encoding="utf-8")
+        return True
+    except (UnicodeDecodeError, OSError):
+        return False
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Scaffold a new Comet example from templates/integration-example."
+    )
+    parser.add_argument("name", help="Example name, e.g. 'pytorch-amp-example'.")
+    parser.add_argument(
+        "--description",
+        default=None,
+        help="One-line description (printed; paste into the README intro).",
+    )
+    parser.add_argument(
+        "--dest",
+        default="integrations",
+        help="Parent directory for the new example (default: integrations). "
+        "Relative paths are resolved from the repo root; absolute paths are used as-is.",
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=None,
+        help="Repo root (default: inferred from this script).",
+    )
+    args = parser.parse_args()
+
+    repo_root = (
+        Path(args.repo_root).resolve()
+        if args.repo_root
+        else Path(__file__).resolve().parents[4]
+    )
+    template = repo_root.joinpath(*TEMPLATE_DIR)
+
+    pkg = to_snake(args.name)
+    kebab = to_kebab(pkg)
+
+    if not template.is_dir():
+        print(f"error: template not found at {template}", file=sys.stderr)
+        return 1
+
+    dest_parent = (
+        Path(args.dest) if Path(args.dest).is_absolute() else repo_root / args.dest
+    )
+    dest = dest_parent / kebab
+    if dest.exists():
+        print(f"error: {dest} already exists — refusing to overwrite.", file=sys.stderr)
+        return 1
+
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(template, dest, ignore=EXCLUDE)
+
+    # Rename the module file (script kind).
+    mod_file = dest / f"{PKG_SENTINEL}.py"
+    if mod_file.is_file():
+        mod_file.rename(dest / f"{pkg}.py")
+
+    # Rewrite sentinels in every text file. Snake and kebab sentinels don't overlap
+    # (underscore vs hyphen), so independent replacement is safe.
+    for path in dest.rglob("*"):
+        if not path.is_file() or not is_text(path):
+            continue
+        text = path.read_text(encoding="utf-8")
+        new = text.replace(PKG_SENTINEL, pkg).replace(PROJECT_SENTINEL, kebab)
+        if new != text:
+            path.write_text(new, encoding="utf-8")
+
+    try:
+        rel = dest.relative_to(repo_root)
+    except ValueError:
+        rel = dest
+    print(f"Scaffolded {rel}")
+    print(f"  folder:        {kebab}/")
+    print(f"  script:        {pkg}.py")
+    print(f"  comet project: comet-example-{kebab}")
+    if args.description:
+        print(f"  description:   {args.description}")
+    print("\nNext steps:")
+    print(f"  1. cd {rel} && python -m pip install -r requirements.txt")
+    print(f"  2. Fill in {pkg}.py (real logic) and the README sections (intro, links).")
+    print(f"  3. Run it: python {pkg}.py   (or: COMET_MODE=offline python {pkg}.py)")
+    print("  4. To test it in CI, add it to .github/workflows/test-examples.yml.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/scaffold-example/scripts/scaffold.py
+++ b/.claude/skills/scaffold-example/scripts/scaffold.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """Scaffold a new Comet example by copying and renaming the canonical template.
 
-One template lives under `templates/integration-example/`: a single `comet_ml` script, a
-`requirements.txt`, and a README in the house structure. It is a real, runnable example under a
+One template lives under `templates/integration-example/`: a `pyproject.toml`, a single `comet_ml`
+script, and a README in the house structure. It is a real, runnable example under a
 sentinel identity (`example_integration` / `example-integration`). This script copies it to the
 target directory and rewrites those sentinels to the new name — a pure identifier rename, no
 template language. Run it, then fill in the TODO stubs.
@@ -21,7 +21,7 @@ PKG_SENTINEL = "example_integration"  # snake_case: the .py module name
 PROJECT_SENTINEL = "example-integration"  # kebab-case: folder + comet project name
 
 EXCLUDE = shutil.ignore_patterns(
-    ".venv", "__pycache__", "*.pyc", ".ruff_cache", ".env", "*.log", ".tmp"
+    ".venv", "uv.lock", "__pycache__", "*.pyc", ".ruff_cache", ".env", "*.log", ".tmp"
 )
 
 
@@ -54,7 +54,7 @@ def main() -> int:
     parser.add_argument(
         "--description",
         default=None,
-        help="One-line description (printed; paste into the README intro).",
+        help="One-line description (written to pyproject.toml).",
     )
     parser.add_argument(
         "--dest",
@@ -109,6 +109,19 @@ def main() -> int:
         if new != text:
             path.write_text(new, encoding="utf-8")
 
+    # Description -> pyproject.toml.
+    if args.description:
+        pyproject = dest / "pyproject.toml"
+        text = pyproject.read_text(encoding="utf-8")
+        text = re.sub(
+            r'^description = ".*"$',
+            f'description = "{args.description}"',
+            text,
+            count=1,
+            flags=re.MULTILINE,
+        )
+        pyproject.write_text(text, encoding="utf-8")
+
     try:
         rel = dest.relative_to(repo_root)
     except ValueError:
@@ -120,9 +133,13 @@ def main() -> int:
     if args.description:
         print(f"  description:   {args.description}")
     print("\nNext steps:")
-    print(f"  1. cd {rel} && python -m pip install -r requirements.txt")
-    print(f"  2. Fill in {pkg}.py (real logic) and the README sections (intro, links).")
-    print(f"  3. Run it: python {pkg}.py   (or: COMET_MODE=offline python {pkg}.py)")
+    print(f"  1. cd {rel} && uv sync")
+    print(
+        f"  2. Fill in {pkg}.py (real logic), pyproject.toml deps, and the README sections."
+    )
+    print(
+        f"  3. Run it: uv run python {pkg}.py   (or: COMET_MODE=offline uv run python {pkg}.py)"
+    )
     print("  4. To test it in CI, add it to .github/workflows/test-examples.yml.")
     return 0
 

--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,8 @@ data/*
 # pytest
 .pytest_cache/
 MagicMock/
+
+# Tooling / agent harness
+.ruff_cache/
+.tmp/
+*-workspace/   # skill eval scratch (e.g. skill-creator benchmarks) — never commit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ Most examples log a real run, so they need an API key. Where it is practical, le
 without an account using Comet's offline mode — no code change required:
 
 ```bash
-COMET_MODE=offline python <example>.py
+COMET_MODE=offline uv run python <example>.py
 ```
 
 Note this in the README's run section when it works. Don't force it onto examples that genuinely
@@ -90,16 +90,14 @@ code does. Use a one-line `# WHY:` comment only when a behaviour would surprise 
 API constraint, a non-obvious ordering requirement, a known gotcha). No type-hint or docstring
 mandate — match the surrounding file.
 
-### Dependencies — a `requirements.txt` per example
+### Dependencies — new examples use `uv` + `pyproject.toml`
 
-Every example ships a `requirements.txt` **sibling to its entry point** (script or notebook
-directory). This is the single source of truth and is exactly what CI installs
-(`pip install -r requirements.txt`). Pin `comet_ml` like the rest of the repo (`comet_ml>=3.44.0`)
-plus the framework deps.
+New examples are `uv` projects: declare dependencies in `pyproject.toml` (the single source of
+truth), install with `uv sync`, and run with `uv run`. Pin `comet_ml>=3.44.0` plus the framework
+deps. Don't assume a repo-wide virtualenv is active.
 
-Richer, multi-file projects **may** use Poetry with a committed `poetry.lock` (see
-[`integrations/langgraph/`](integrations/langgraph/)). Do **not** introduce `uv`, and do **not**
-gitignore `poetry.lock` — this repo commits it for reproducibility.
+Existing examples that ship a `requirements.txt` (most of the repo) are **legacy and stay as they
+are** — don't migrate them in passing. Only new examples follow the `uv` convention.
 
 ## Coding best practices
 
@@ -118,12 +116,14 @@ gitignore `poetry.lock` — this repo commits it for reproducibility.
 ## CI
 
 Tests run via [`.github/workflows/test-examples.yml`](.github/workflows/test-examples.yml), which
-holds **explicit matrices** of notebooks and scripts — examples are not auto-discovered. To get a
-new example covered:
+holds **explicit matrices** of notebooks and scripts — examples are not auto-discovered. The
+workflow installs deps with `pip install -r requirements.txt` (it has not been migrated to `uv`).
+To get a new example covered:
 
-1. Make sure its `requirements.txt` is complete and the example runs from its own directory.
-2. Add it to the matrix — the `notebooks` list (run with `ipython`) for a `.ipynb`, or the
+1. Add it to the matrix — the `notebooks` list (run with `ipython`) for a `.ipynb`, or the
    `example` list (run with `python <script> <arg>`) for a script.
+2. Because the workflow uses pip, also include a `requirements.txt` alongside the `pyproject.toml`
+   (`uv export --no-hashes -o requirements.txt`) so the matrix can install it.
 
 An example without a matrix entry is valid but won't be tested.
 
@@ -135,8 +135,8 @@ Follow the house structure used across the repo (see
 1. **Title + intro** — what the framework is and what instrumenting it with Comet gives you
 2. **Documentation** — link to the relevant page on `comet.com/docs`
 3. **See it** — link to a public Comet project, when one exists
-4. **Setup** — `python -m pip install -r requirements.txt`
-5. **Run the example** — the exact command (and the offline variant when it applies)
+4. **Setup** — `uv sync`
+5. **Run the example** — the exact command (`uv run python <name>.py`, and the offline variant when it applies)
 
 Keep the README in sync with the code and update it before every PR.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,146 @@
+# Agent instructions for comet-examples
+
+This repo is a reference library of examples for [Comet](https://www.comet.com/site/), the ML
+experiment-tracking, model-management, and observability platform. Examples instrument popular ML
+frameworks (PyTorch, Keras, fastai, scikit-learn, XGBoost, Transformers, …) with `comet_ml`. Read
+this file before generating or editing any code.
+
+## Repo structure
+
+```
+comet-examples/
+├── integrations/   # Add Comet to a framework, grouped by ML task (see below)
+├── guides/         # How-to notebooks for Comet workflows
+├── panels/         # Custom Comet panel (visualization) examples
+├── notebooks/      # General/standalone notebooks
+└── templates/      # Starter template (integration-example)
+```
+
+`integrations/` is grouped by ML task, then by framework, then by example:
+
+```
+integrations/<category>/<framework>/<example-name>/
+```
+
+Categories in use: `model-training`, `model-evaluation`, `model-optimization`, `model-deployment`,
+`workflow-orchestration`, `reinforcement-learning`, `llm`, `data-management`.
+
+**Where does new code belong?**
+
+| If you are… | Put it in |
+|---|---|
+| Instrumenting a framework with Comet (the common case) | `integrations/<category>/<framework>/<example-name>/` |
+| Writing a how-to notebook for a Comet workflow | `guides/` |
+| Building a custom Comet panel | `panels/` |
+
+New examples go under `integrations/`. The top-level legacy dirs (`pytorch/`, `fastai/`,
+`xgboost/`, `keras/`, `tensorflow/`) are historical — **do not add new examples there.** Example
+folder names are **kebab-case** (`pytorch-mnist`, `fastai-hello-world`).
+
+When adding an example, use the [`scaffold-example`](.claude/skills/scaffold-example/SKILL.md)
+skill — it stamps [`templates/integration-example/`](templates/integration-example/) into the
+target directory and renames it for you.
+
+## Non-negotiable conventions
+
+### Credentials — always from environment variables
+
+```python
+import os
+
+COMET_API_KEY  = os.environ.get("COMET_API_KEY")
+COMET_WORKSPACE = os.environ.get("COMET_WORKSPACE")
+```
+
+Never hardcode keys. Never read `.env` files in example code. In CI the workspace is
+`cometexamples-tests` and `COMET_API_KEY` comes from a secret.
+
+### The Comet SDK idiom
+
+Match the house style used across the repo:
+
+```python
+import comet_ml
+
+comet_ml.login(project_name="comet-example-<name>")
+experiment = comet_ml.start()
+# ... training / logging ...
+experiment.end()
+```
+
+`comet_ml.login()` reads `COMET_API_KEY` from the environment. Project names follow
+`comet-example-<framework>-<thing>`.
+
+### Offline mode — the no-account path (recommended, not required)
+
+Most examples log a real run, so they need an API key. Where it is practical, let a reader run
+without an account using Comet's offline mode — no code change required:
+
+```bash
+COMET_MODE=offline python <example>.py
+```
+
+Note this in the README's run section when it works. Don't force it onto examples that genuinely
+need a live run.
+
+### Comments — only when the WHY is non-obvious
+
+These are teaching examples: keep them short and readable. Don't add comments that restate what the
+code does. Use a one-line `# WHY:` comment only when a behaviour would surprise a reader (a hidden
+API constraint, a non-obvious ordering requirement, a known gotcha). No type-hint or docstring
+mandate — match the surrounding file.
+
+### Dependencies — a `requirements.txt` per example
+
+Every example ships a `requirements.txt` **sibling to its entry point** (script or notebook
+directory). This is the single source of truth and is exactly what CI installs
+(`pip install -r requirements.txt`). Pin `comet_ml` like the rest of the repo (`comet_ml>=3.44.0`)
+plus the framework deps.
+
+Richer, multi-file projects **may** use Poetry with a committed `poetry.lock` (see
+[`integrations/langgraph/`](integrations/langgraph/)). Do **not** introduce `uv`, and do **not**
+gitignore `poetry.lock` — this repo commits it for reproducibility.
+
+## Coding best practices
+
+- **Principles:** DRY, KISS, YAGNI. Prefer reusing an existing helper over adding a new one.
+- **Match the surrounding file's** style, naming, and comment density.
+- **Git / PR safety:**
+  - Never `git commit` or `git push` on `master`. Cut a feature branch (`<user>/<topic>`, e.g.
+    `fschlz/pytorch-amp-example`), push there, open a PR, and let a human merge.
+  - Commits follow **Conventional Commits**: `feat:`, `fix:`, `chore:`, `refactor:`, `docs:`.
+  - Never `gh pr merge`, `gh pr close`, or `gh pr review --approve` — author/reviewer actions only.
+    Blocked in [`.claude/settings.json`](.claude/settings.json).
+  - No AI-attribution footers in commit messages or PR bodies.
+  - **Update READMEs before opening a PR** — the example's own `README.md`, and the root
+    [`readme.md`](readme.md) if you add a new top-level area.
+
+## CI
+
+Tests run via [`.github/workflows/test-examples.yml`](.github/workflows/test-examples.yml), which
+holds **explicit matrices** of notebooks and scripts — examples are not auto-discovered. To get a
+new example covered:
+
+1. Make sure its `requirements.txt` is complete and the example runs from its own directory.
+2. Add it to the matrix — the `notebooks` list (run with `ipython`) for a `.ipynb`, or the
+   `example` list (run with `python <script> <arg>`) for a script.
+
+An example without a matrix entry is valid but won't be tested.
+
+## Every example must have a README.md
+
+Follow the house structure used across the repo (see
+[`templates/integration-example/README.md`](templates/integration-example/README.md)):
+
+1. **Title + intro** — what the framework is and what instrumenting it with Comet gives you
+2. **Documentation** — link to the relevant page on `comet.com/docs`
+3. **See it** — link to a public Comet project, when one exists
+4. **Setup** — `python -m pip install -r requirements.txt`
+5. **Run the example** — the exact command (and the offline variant when it applies)
+
+Keep the README in sync with the code and update it before every PR.
+
+## Full contribution guide
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the complete standards, the recommended
+plan → brainstorm → branch → implement → test → READMEs → PR → review workflow, and the PR checklist.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,8 +53,8 @@ new examples there. If you're unsure, open an issue and ask.
 ## Adding an example
 
 [`templates/integration-example/`](templates/integration-example/) is a minimal, runnable Comet
-example: a single `comet_ml` script, a `requirements.txt`, and a README in the house structure. New
-examples start from it.
+example: a `uv` project (`pyproject.toml`), a single `comet_ml` script, and a README in the house
+structure. New examples start from it.
 
 **Easiest path (recommended):** use the `scaffold-example` skill — it copies the template and
 renames it for you:
@@ -74,9 +74,9 @@ cp -r templates/integration-example integrations/<category>/<framework>/my-examp
 
 Then, either way:
 
-1. `cd` into the new folder and `python -m pip install -r requirements.txt`.
-2. Fill in the script (real logic) and the README sections.
-3. Run it from the folder: `python <name>.py` (and check the offline variant if it applies).
+1. `cd` into the new folder and `uv sync`.
+2. Fill in the script (real logic), the `pyproject.toml` deps, and the README sections.
+3. Run it from the folder: `uv run python <name>.py` (and check the offline variant if it applies).
 4. If it should be tested in CI, add it to `.github/workflows/test-examples.yml` (see [CI](#ci)).
 5. Open a PR and fill in the checklist below.
 
@@ -85,7 +85,7 @@ Then, either way:
 ### Every example must have
 
 - A `README.md` in the house structure (below)
-- A complete `requirements.txt` sibling to its entry point
+- A `pyproject.toml` declaring its dependencies (`uv` project)
 - Credentials loaded from environment variables only — no hardcoded keys
 
 ### README structure
@@ -95,8 +95,8 @@ Follow the structure used across the repo (see the template's README):
 - **Title + intro** — what the framework is and what Comet adds
 - **Documentation** — link to the relevant `comet.com/docs` page
 - **See it** — link to a public Comet project, when one exists
-- **Setup** — `python -m pip install -r requirements.txt`
-- **Run the example** — the exact command (and the offline variant when it applies)
+- **Setup** — `uv sync`
+- **Run the example** — the exact command (`uv run python <name>.py`, and the offline variant when it applies)
 
 ### Credentials
 
@@ -118,17 +118,18 @@ Where it's practical, let a reader run without an account using Comet's offline 
 the README:
 
 ```bash
-COMET_MODE=offline python <example>.py
+COMET_MODE=offline uv run python <example>.py
 ```
 
 Don't force it onto examples that genuinely need a live run.
 
 ### Dependencies
 
-Each example declares its dependencies in a `requirements.txt` sibling to its entry point — this is
-the single source of truth and what CI installs. Pin `comet_ml>=3.44.0` plus the framework deps.
-Richer multi-file projects may use Poetry with a committed `poetry.lock` (e.g.
-`integrations/langgraph/`). Don't introduce `uv`.
+New examples are `uv` projects: declare dependencies in `pyproject.toml` (the single source of
+truth), install with `uv sync`, run with `uv run`. Pin `comet_ml>=3.44.0` plus the framework deps.
+
+Existing examples that ship a `requirements.txt` are legacy and stay as they are — don't migrate
+them in passing.
 
 ### Code style
 
@@ -147,7 +148,9 @@ the matrix:
 - **Script** → add `{script: "<path>", arg: "<args>"}` to the `example` list (run with
   `python <script> <args>`).
 
-Make sure the example installs cleanly from its own `requirements.txt` first.
+The workflow installs deps with `pip install -r requirements.txt` (it hasn't been migrated to
+`uv`). So a new `uv` example that you want in CI also needs a `requirements.txt` alongside its
+`pyproject.toml` — generate it with `uv export --no-hashes -o requirements.txt`.
 
 ## PR checklist
 
@@ -157,8 +160,8 @@ Before opening a PR, verify:
 - [ ] Folder name is kebab-case (e.g. `my-framework-hello-world`)
 - [ ] `README.md` has the house sections
 - [ ] READMEs updated — the example's `README.md`, and the root `readme.md` if you added a new area
-- [ ] `requirements.txt` is complete and the example runs from its own directory
-- [ ] Added to the CI matrix in `test-examples.yml` if it should be tested
+- [ ] `pyproject.toml` is complete and the example runs (`uv run python <name>.py`)
+- [ ] Added to the CI matrix in `test-examples.yml` if it should be tested (with a `requirements.txt` for the pip-based workflow)
 - [ ] No credentials or `.env` files committed
 
 ## Questions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,167 @@
+# Contributing to comet-examples
+
+Thank you for contributing. This repo is a reference library for Comet users — the goal is examples
+that are easy to find, easy to run, and easy to adapt. Contributions come from both humans and AI
+agents; the same standards apply to both. Agents should also read [AGENTS.md](AGENTS.md).
+
+## Recommended workflow
+
+This is the loop we follow for non-trivial contributions. The slash-commands in brackets come from
+Claude Code plugins (see below) and are optional but recommended.
+
+1. **Plan first.** Switch Claude Code to plan mode on the best available model with reasoning effort
+   maxed before writing any code.
+2. **Brainstorm the scope** (`/brainstorming`) — agree on *what* to build before *how*.
+3. **Write the plan** (`/writing-plans`) — turn the agreed scope into an implementation plan.
+4. **Cut a feature branch** — `git switch -c <user>/<topic>` (never commit on `master`).
+5. **Implement and commit frequently** — small [Conventional Commits](https://www.conventionalcommits.org/)
+   (`feat:`, `fix:`, `chore:`, `refactor:`, `docs:`).
+6. **Test and fix** — run the example from its own directory until it works.
+7. **Update the READMEs** — the example's own README, and the root `readme.md` if you added a new area.
+8. **Open a PR with a description** — what changed and why. A human merges it.
+9. **Review the diff** (`/review`) before requesting human review.
+
+**Recommended Claude Code plugins:** `superpowers` (provides `/brainstorming`, `/writing-plans`, and
+`/review`) and `caveman` (terse output mode).
+
+## Repo structure
+
+```
+comet-examples/
+├── integrations/   # Add Comet to a framework, grouped by ML task
+├── guides/         # How-to notebooks for Comet workflows
+├── panels/         # Custom Comet panel examples
+├── notebooks/      # General/standalone notebooks
+└── templates/      # Starter template (integration-example)
+```
+
+New examples go under `integrations/<category>/<framework>/<example-name>/`. Categories in use:
+`model-training`, `model-evaluation`, `model-optimization`, `model-deployment`,
+`workflow-orchestration`, `reinforcement-learning`, `llm`, `data-management`.
+
+**Which bucket does my example belong in?**
+
+| Question | Bucket |
+|---|---|
+| I'm instrumenting a framework with Comet (the common case) | `integrations/<category>/<framework>/` |
+| I'm showing how to do something with Comet itself in a notebook | `guides/` |
+| I'm building a custom Comet panel | `panels/` |
+
+The top-level dirs `pytorch/`, `fastai/`, `keras/`, `tensorflow/`, `xgboost/` are legacy — don't add
+new examples there. If you're unsure, open an issue and ask.
+
+## Adding an example
+
+[`templates/integration-example/`](templates/integration-example/) is a minimal, runnable Comet
+example: a single `comet_ml` script, a `requirements.txt`, and a README in the house structure. New
+examples start from it.
+
+**Easiest path (recommended):** use the `scaffold-example` skill — it copies the template and
+renames it for you:
+
+```bash
+python .claude/skills/scaffold-example/scripts/scaffold.py my-framework-hello-world \
+  --description "What it does" \
+  --dest integrations/model-training/my-framework
+```
+
+**By hand:** copy the template and rename its `example_integration` / `example-integration`
+identifiers across the files:
+
+```bash
+cp -r templates/integration-example integrations/<category>/<framework>/my-example
+```
+
+Then, either way:
+
+1. `cd` into the new folder and `python -m pip install -r requirements.txt`.
+2. Fill in the script (real logic) and the README sections.
+3. Run it from the folder: `python <name>.py` (and check the offline variant if it applies).
+4. If it should be tested in CI, add it to `.github/workflows/test-examples.yml` (see [CI](#ci)).
+5. Open a PR and fill in the checklist below.
+
+## Standards
+
+### Every example must have
+
+- A `README.md` in the house structure (below)
+- A complete `requirements.txt` sibling to its entry point
+- Credentials loaded from environment variables only — no hardcoded keys
+
+### README structure
+
+Follow the structure used across the repo (see the template's README):
+
+- **Title + intro** — what the framework is and what Comet adds
+- **Documentation** — link to the relevant `comet.com/docs` page
+- **See it** — link to a public Comet project, when one exists
+- **Setup** — `python -m pip install -r requirements.txt`
+- **Run the example** — the exact command (and the offline variant when it applies)
+
+### Credentials
+
+Always load from environment variables:
+
+```python
+import os
+
+api_key   = os.environ["COMET_API_KEY"]
+workspace = os.environ["COMET_WORKSPACE"]
+```
+
+`comet_ml.login()` picks up `COMET_API_KEY` automatically. Never commit `.env` files or hardcoded
+keys.
+
+### Offline mode (optional)
+
+Where it's practical, let a reader run without an account using Comet's offline mode and note it in
+the README:
+
+```bash
+COMET_MODE=offline python <example>.py
+```
+
+Don't force it onto examples that genuinely need a live run.
+
+### Dependencies
+
+Each example declares its dependencies in a `requirements.txt` sibling to its entry point — this is
+the single source of truth and what CI installs. Pin `comet_ml>=3.44.0` plus the framework deps.
+Richer multi-file projects may use Poetry with a committed `poetry.lock` (e.g.
+`integrations/langgraph/`). Don't introduce `uv`.
+
+### Code style
+
+- These are teaching examples — keep them short and readable
+- No comments that explain what the code does — well-named variables and functions do that
+- A short `# WHY:` comment is appropriate when a behaviour would surprise a reader
+- No emojis
+
+## CI
+
+[`.github/workflows/test-examples.yml`](.github/workflows/test-examples.yml) tests an **explicit
+list** of notebooks and scripts — examples are not auto-discovered. To get yours covered, add it to
+the matrix:
+
+- **Notebook** → add its path to the `notebooks` list (run with `ipython`).
+- **Script** → add `{script: "<path>", arg: "<args>"}` to the `example` list (run with
+  `python <script> <args>`).
+
+Make sure the example installs cleanly from its own `requirements.txt` first.
+
+## PR checklist
+
+Before opening a PR, verify:
+
+- [ ] Example is in the right place (`integrations/<category>/<framework>/`, or `guides/` / `panels/`)
+- [ ] Folder name is kebab-case (e.g. `my-framework-hello-world`)
+- [ ] `README.md` has the house sections
+- [ ] READMEs updated — the example's `README.md`, and the root `readme.md` if you added a new area
+- [ ] `requirements.txt` is complete and the example runs from its own directory
+- [ ] Added to the CI matrix in `test-examples.yml` if it should be tested
+- [ ] No credentials or `.env` files committed
+
+## Questions
+
+Open an issue or start a discussion. We're happy to help you figure out the right bucket or approach
+before you write the code.

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 <img src="https://www.comet.com/images/logo_comet_light.png" width="350" alt="Drawing" style="width: 350px;"/>
 
 ## Comet for Machine Learning Experiment Management
-**Our Misson:** Comet is doing for ML what GitHub did for code. We allow data science teams to automagically track their datasets, code changes, experimentation history and production models creating efficiency, transparency, and reproducibility. 
+**Our Misson:** Comet is doing for ML what GitHub did for code. We allow data science teams to automagically track their datasets, code changes, experimentation history and production models creating efficiency, transparency, and reproducibility.
 
 We all strive to be data driven and yet every day valuable experiment results are lost and forgotten. Comet provides a dead simple way of fixing that. It works with any workflow, any ML task, any machine, and any piece of code.
 
@@ -10,6 +10,27 @@ We all strive to be data driven and yet every day valuable experiment results ar
 This repository contains examples of using Comet in many Machine Learning Python libraries, including fastai, torch, sklearn, chainer, caffe, keras, tensorflow, mxnet, Jupyter notebooks, and with just pre Python.
 
 If you don't see something you need, just let us know! See contact methods below.
+
+## Repository structure
+
+```
+comet-examples/
+├── integrations/   # Add Comet to a framework, grouped by ML task
+│   ├── model-training/        # PyTorch, Keras, fastai, scikit-learn, XGBoost, Transformers, …
+│   ├── model-evaluation/
+│   ├── model-optimization/
+│   ├── model-deployment/
+│   ├── workflow-orchestration/
+│   ├── reinforcement-learning/
+│   ├── llm/
+│   └── data-management/
+├── guides/         # How-to notebooks for Comet workflows
+├── panels/         # Custom Comet panel (visualization) examples
+├── notebooks/      # General/standalone notebooks
+└── templates/      # Starter template for new examples
+```
+
+New examples live under `integrations/<category>/<framework>/<example-name>/`.
 
 ## Documentation
 [![PyPI version](https://badge.fury.io/py/comet-ml.svg)](https://badge.fury.io/py/comet-ml)
@@ -30,17 +51,24 @@ Comet Python SDK is compatible with: __Python 3.5-3.13__.
 ## Tutorials + Examples
 
 - [fastai](https://github.com/comet-ml/comet-examples/tree/master/integrations/model-training/fastai/)
-- [keras](https://github.com/comet-ml/comet-examples/tree/master/keras)
-- [pytorch](https://github.com/comet-ml/comet-examples/tree/master/pytorch)
-- [scikit](https://github.com/comet-ml/comet-examples/tree/master/integrations/model-training/scikit-learn)
-- [tensorflow](https://github.com/comet-ml/comet-examples/tree/master/tensorflow)
+- [keras](https://github.com/comet-ml/comet-examples/tree/master/integrations/model-training/keras/)
+- [pytorch](https://github.com/comet-ml/comet-examples/tree/master/integrations/model-training/pytorch/)
+- [scikit](https://github.com/comet-ml/comet-examples/tree/master/integrations/model-training/scikit-learn/)
+- [tensorflow](https://github.com/comet-ml/comet-examples/tree/master/integrations/model-training/tensorflow/)
+- [transformers](https://github.com/comet-ml/comet-examples/tree/master/integrations/model-training/transformers/)
 
-## Support 
-Have questions? We have answers - 
+## Contributing
+
+Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for the workflow, standards, and
+PR checklist, and [AGENTS.md](AGENTS.md) for the conventions AI coding agents should follow. New
+examples can be scaffolded from [`templates/integration-example/`](templates/integration-example/).
+
+## Support
+Have questions? We have answers -
 - Email us at <info@comet.com>
 - For the fastest response, ping us on [Slack](https://chat.comet.com/)
 
-**Want to request a feature?** 
+**Want to request a feature?**
 We take feature requests through github at: https://github.com/comet-ml/issue-tracking
 
 ## Feature Spotlight

--- a/templates/integration-example/README.md
+++ b/templates/integration-example/README.md
@@ -1,9 +1,9 @@
-# <Framework> integration with Comet
+# {Framework} integration with Comet
 
 <!-- TODO: one paragraph — what the framework is, and what instrumenting it with Comet gives you
      (experiment tracking, hyperparameter logging, reproducibility, collaboration). -->
 
-Instrument <Framework> with Comet to start managing experiments, create dataset versions, and track
+Instrument {Framework} with Comet to start managing experiments, create dataset versions, and track
 hyperparameters for faster, easier reproducibility and collaboration.
 
 ## Documentation
@@ -17,20 +17,20 @@ For more information on using and configuring the integration, see:
 
 ## Setup
 
-Install dependencies
+Install dependencies with [uv](https://docs.astral.sh/uv/):
 
 ```bash
-python -m pip install -r requirements.txt
+uv sync
 ```
 
 ## Run the example
 
 ```bash
-python example_integration.py
+uv run python example_integration.py
 ```
 
 No Comet account? Run it offline (logs to a local archive instead of the Comet UI):
 
 ```bash
-COMET_MODE=offline python example_integration.py
+COMET_MODE=offline uv run python example_integration.py
 ```

--- a/templates/integration-example/README.md
+++ b/templates/integration-example/README.md
@@ -1,0 +1,36 @@
+# <Framework> integration with Comet
+
+<!-- TODO: one paragraph — what the framework is, and what instrumenting it with Comet gives you
+     (experiment tracking, hyperparameter logging, reproducibility, collaboration). -->
+
+Instrument <Framework> with Comet to start managing experiments, create dataset versions, and track
+hyperparameters for faster, easier reproducibility and collaboration.
+
+## Documentation
+
+For more information on using and configuring the integration, see:
+[https://www.comet.com/docs/v2/](https://www.comet.com/docs/v2/) <!-- TODO: link the specific integration page -->
+
+## See it
+
+<!-- TODO: link a public Comet project showing this example's runs, if one exists. -->
+
+## Setup
+
+Install dependencies
+
+```bash
+python -m pip install -r requirements.txt
+```
+
+## Run the example
+
+```bash
+python example_integration.py
+```
+
+No Comet account? Run it offline (logs to a local archive instead of the Comet UI):
+
+```bash
+COMET_MODE=offline python example_integration.py
+```

--- a/templates/integration-example/example_integration.py
+++ b/templates/integration-example/example_integration.py
@@ -1,0 +1,14 @@
+# coding: utf-8
+import comet_ml
+
+# WHY: comet_ml.login() reads COMET_API_KEY from the environment — never hardcode it.
+comet_ml.login(project_name="comet-example-example-integration")
+experiment = comet_ml.start()
+
+# TODO: replace this stub with your framework's real training / inference loop.
+#       Log whatever is useful, e.g. experiment.log_parameters({...}),
+#       experiment.log_metrics({...}), experiment.log_model(...).
+for step in range(10):
+    experiment.log_metric("loss", 1.0 / (step + 1), step=step)
+
+experiment.end()

--- a/templates/integration-example/pyproject.toml
+++ b/templates/integration-example/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "example-integration"
+version = "0.1.0"
+description = "TODO: one-line description of what this example does"
+requires-python = ">=3.10"
+dependencies = [
+    "comet_ml>=3.44.0",
+    # TODO: add your framework dependency, e.g. torch, fastai, scikit-learn, transformers
+]
+
+# WHY: this example is a script to run, not a library to install — keep uv from trying to build it.
+[tool.uv]
+package = false

--- a/templates/integration-example/requirements.txt
+++ b/templates/integration-example/requirements.txt
@@ -1,2 +1,0 @@
-comet_ml>=3.44.0
-# TODO: add your framework dependency, e.g. torch, fastai, scikit-learn, transformers

--- a/templates/integration-example/requirements.txt
+++ b/templates/integration-example/requirements.txt
@@ -1,0 +1,2 @@
+comet_ml>=3.44.0
+# TODO: add your framework dependency, e.g. torch, fastai, scikit-learn, transformers


### PR DESCRIPTION
## What

Adds a contributor + AI-agent harness so new examples land in a consistent, documented shape.

- **`.claude/settings.json`** — agent guardrails: deny destructive git (`reset --hard`, `rebase`, `merge`, `branch -D`), `gh pr merge/close/review`, and `.env` reads.
- **`AGENTS.md`** / **`CONTRIBUTING.md`** — conventions for agents and humans: the `comet_ml.login()` + `start()` idiom, env-var credentials, optional offline mode, the house README structure, kebab-case naming, and how to wire an example into CI.
- **`templates/integration-example/`** — a minimal, runnable `comet_ml` example (`uv` + `pyproject.toml`) to start new examples from.
- **`.claude/skills/scaffold-example/`** — a skill + generator that stamps the template into the right directory and renames it.
- **`readme.md`** — adds repository-structure and contributing sections; fixes stale tutorial links to the current `integrations/model-training/...` paths.
- **`.gitignore`** — adds `.ruff_cache/`, `.tmp/`, `*-workspace/`.

## Conventions

- **New examples** are `uv` projects: dependencies in `pyproject.toml`, run with `uv run`. Existing `requirements.txt` examples are legacy and stay as they are.
- Credentials from environment variables only; offline mode (`COMET_MODE=offline`) documented as the no-account path.
- Example folders are kebab-case under `integrations/<category>/<framework>/`.
- CI (`test-examples.yml`) still installs via `pip install -r requirements.txt`, so a new `uv` example that wants CI coverage also ships a `requirements.txt` (`uv export`).

## Verification

- Scaffolder round-trips: `scaffold.py keras-amp-demo --description "..."` → correct folder/file/project rename, description written to `pyproject.toml`, no leftover sentinels.
- Template + scaffold parse; `settings.json` valid JSON; `pyproject.toml` valid TOML.
- All referenced `integrations/...` paths exist; pre-commit (ruff-format) clean.